### PR TITLE
Adding pagination parameters to products request

### DIFF
--- a/src/Api/Handler/Request/Catalog/ProductHandler.php
+++ b/src/Api/Handler/Request/Catalog/ProductHandler.php
@@ -108,14 +108,19 @@ class ProductHandler extends HandlerAbstract
 
     /**
      * @param null|string $status
+     * @param null|array $paging
      *
      * @return \SkyHub\Api\Handler\Response\HandlerInterface
      */
-    public function products($status = null)
+    public function products($status = null, $paging = null)
     {
         $query = [
             'status' => $status
         ];
+        
+        if ($paging and is_array($paging)) {
+            $query = array_merge($query, $paging);
+        }
 
         /** @var \SkyHub\Api\Handler\Response\HandlerInterface $responseHandler */
         $responseHandler = $this->service()->get($this->baseUrlPath(null, $query));


### PR DESCRIPTION
Alows that pagination parameters be passed (page and per_page) on products catalog request;

Reference: https://skyhub-english.gitbook.io/skyhub-api-english/pagination-and-filters