### PR TITLE
Passando offset na request "Lista de Pedidos Aptos ao Agrupamento"

### DIFF
--- a/src/Api/Handler/Request/Shipment/PlpHandler.php
+++ b/src/Api/Handler/Request/Shipment/PlpHandler.php
@@ -54,7 +54,7 @@ class PlpHandler extends HandlerAbstract
         ];
         
         /** @var \SkyHub\Api\Handler\Response\HandlerInterface $responseHandler */
-        $responseHandler = $this->service()->get($this->baseUrlPath('/to_group'), $query);
+        $responseHandler = $this->service()->get($this->baseUrlPath('/to_group', $query));
 
         return $responseHandler;
     }

--- a/src/Api/Handler/Request/Shipment/PlpHandler.php
+++ b/src/Api/Handler/Request/Shipment/PlpHandler.php
@@ -50,7 +50,7 @@ class PlpHandler extends HandlerAbstract
     public function ordersReadyToGroup(int $offset = 1)
     {
         $query = [
-            'offset'   => $offset
+            'offset'   => $offset > 0 ? $offset : 1
         ];
         
         /** @var \SkyHub\Api\Handler\Response\HandlerInterface $responseHandler */

--- a/src/Api/Handler/Request/Shipment/PlpHandler.php
+++ b/src/Api/Handler/Request/Shipment/PlpHandler.php
@@ -44,12 +44,17 @@ class PlpHandler extends HandlerAbstract
     /**
      * Retrieves a list of all orders ready to be grouped in a PLP.
      *
+     * @param int $offset default 1
      * @return \SkyHub\Api\Handler\Response\HandlerInterface
      */
-    public function ordersReadyToGroup()
+    public function ordersReadyToGroup(int $offset = 1)
     {
+        $query = [
+            'offset'   => $offset
+        ];
+        
         /** @var \SkyHub\Api\Handler\Response\HandlerInterface $responseHandler */
-        $responseHandler = $this->service()->get($this->baseUrlPath('/to_group'));
+        $responseHandler = $this->service()->get($this->baseUrlPath('/to_group'), $query);
 
         return $responseHandler;
     }


### PR DESCRIPTION
Passando offset na request "Lista de Pedidos Aptos ao Agrupamento" assim como manda a documentação da API.

**Exemplo prático:**
```php
/** @var \SkyHub\Api\Handler\Request\Shipment\PlpHandler $requestHandler */
$requestHandler = $api->plp();

/** @var SkyHub\Api\Handler\Response\HandlerInterface $response */
$response = $requestHandler->ordersReadyToGroup(offset: 2);
```


**Documentação**

https://desenvolvedores.skyhub.com.br/etiquetas-b2w-entregas/etiqueta-de-frete-correios#lista-de-pedidos-aptos-ao-agrupamento